### PR TITLE
Support none docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "numba",                      # Use galois's version limitation
     "scipy",
     "matplotlib",
-    "galois == 0.3.8",            # Exact match required because of use of internals
+    "galois == 0.3.9",            # Exact match required because of use of internals
     "typing_extensions >= 4.0.0", # v4.0.0 is needed for use of Self (Python 3.11+) and Literal (Python 3.8+)
 ]
 dynamic = ["version"]

--- a/src/sdr/_helper.py
+++ b/src/sdr/_helper.py
@@ -43,6 +43,8 @@ def extend_docstring(method, replace=None, docstring=""):
 
     def decorator(obj):
         parent_docstring = getattr(method, "__doc__", "")
+        if parent_docstring is None:
+            return obj
         for from_str, to_str in replace.items():
             parent_docstring = parent_docstring.replace(from_str, to_str)
         obj.__doc__ = parent_docstring + "\n" + docstring


### PR DESCRIPTION
Hello,

I ran into an issue running `sdr` code with CPython's `-OO` flag which optimizes out docstrings. The issue can be reproduced by running tests with `python -OO -m pylint tests/`.

This branch contains a solution broken into 2 commits:
1. Check for and handle `None` docstrings within `sdr`'s helper function.
2. Require `galois` version 0.3.9 which brings support for CPython's `-OO` flag.

My branch is based off of `release/0.0.x` & I've ensured it passes `ruff` & the unit tests locally (w/ `-OO`).

Let me know if there's anything I missed or can do to facilitate merging this PR. Thank you in advance.