### PR TITLE
fix: only prepend zeros in polyphase non-streaming when mode="full"

### DIFF
--- a/src/sdr/_filter/_polyphase.py
+++ b/src/sdr/_filter/_polyphase.py
@@ -300,8 +300,11 @@ class PolyphaseFIR(FIR):
 
             self._state = x_pad[-(B * M - 1) :]
         else:
-            # Prepend zeros to so the first sample is alone in the first commutated column
-            x_pad = np.insert(x, 0, np.zeros(B - 1))
+            # Only prepend zeros in "full" mode; in "rate" mode they misalign decimation
+            if mode == "full":
+                x_pad = np.insert(x, 0, np.zeros(B - 1))
+            else:
+                x_pad = x
             # Append zeros to input signal to distribute evenly across the B branches
             x_pad = np.append(x_pad, np.zeros(B - (x_pad.size % B), dtype=dtype))
             X_cols = x_pad.size // B


### PR DESCRIPTION
Fixes the non-streaming polyphase commutate path in `_polyphase_input_commutate`. When `mode="rate"`, B-1 zeros were incorrectly prepended before commuting, misaligning the signal with the decimation. Now fixed — zeros are only prepended in `mode="full"`.

The streaming path uses separate padding logic and is not affected by this change. All 29 multirate tests pass.